### PR TITLE
add go-map to the random get/set benchmark

### DIFF
--- a/main.go
+++ b/main.go
@@ -312,6 +312,12 @@ func main() {
 			lotsa.Ops(N, 1, func(i, _ int) {
 				ttrM.Load(items[i].key, items[i].val)
 			})
+
+			map_ := make(map[keyT]valT)
+			print("go-map:     set            ")
+			lotsa.Ops(N, 1, func(i, _ int) {
+				map_[items[i].key] = items[i].val
+			})
 		}
 		println()
 		println("** random get **")
@@ -322,12 +328,14 @@ func main() {
 		ttr = newTBTree(degree)
 		ttrM = newTBTreeM(degree)
 		ttrG = newTBTreeG(degree)
+		map_ := make(map[keyT]valT)
 		for _, item := range items {
 			gtr.ReplaceOrInsert(item)
 			gtrG.ReplaceOrInsert(item)
 			ttrG.Set(item)
 			ttr.Set(item)
 			ttrM.Set(item.key, item.val)
+			map_[item.key] = item.val
 		}
 		shuffleInts()
 
@@ -382,6 +390,13 @@ func main() {
 				}
 			})
 		}
+		print("go-map:     get            ")
+		lotsa.Ops(N, 1, func(i, _ int) {
+			re, ok := map_[items[i].key]
+			if !ok {
+				panic(re)
+			}
+		})
 	}
 
 	if withRange {


### PR DESCRIPTION
```
degree=32, key=string (16 bytes), val=int64, count=1000000

** sequential set **
google:     set-seq        1,000,000 ops in 529ms, 1,889,331/sec, 529 ns/op, 56.9 MB, 59.6 bytes/op
google(G):  set-seq        1,000,000 ops in 378ms, 2,648,648/sec, 377 ns/op, 49.7 MB, 52.1 bytes/op
tidwall:    set-seq        1,000,000 ops in 379ms, 2,640,442/sec, 378 ns/op, 56.4 MB, 59.1 bytes/op
tidwall(G): set-seq        1,000,000 ops in 318ms, 3,142,789/sec, 318 ns/op, 49.2 MB, 51.6 bytes/op
tidwall(M): set-seq        1,000,000 ops in 263ms, 3,796,111/sec, 263 ns/op, 49.2 MB, 51.6 bytes/op
tidwall:    set-seq-hint   1,000,000 ops in 222ms, 4,502,818/sec, 222 ns/op, 56.4 MB, 59.1 bytes/op
tidwall(G): set-seq-hint   1,000,000 ops in 170ms, 5,896,237/sec, 169 ns/op, 49.2 MB, 51.6 bytes/op
tidwall:    load-seq       1,000,000 ops in 167ms, 5,975,718/sec, 167 ns/op, 56.4 MB, 59.1 bytes/op
tidwall(G): load-seq       1,000,000 ops in 120ms, 8,339,786/sec, 119 ns/op, 49.2 MB, 51.6 bytes/op
tidwall(M): load-seq       1,000,000 ops in 113ms, 8,843,428/sec, 113 ns/op, 49.2 MB, 51.6 bytes/op
go-arr:     append         1,000,000 ops in 69ms, 14,448,440/sec, 69 ns/op, 26.5 MB, 27.7 bytes/op

** sequential get **
google:     get-seq        1,000,000 ops in 361ms, 2,773,070/sec, 360 ns/op
google(G):  get-seq        1,000,000 ops in 246ms, 4,058,051/sec, 246 ns/op
tidwall:    get-seq        1,000,000 ops in 264ms, 3,793,168/sec, 263 ns/op
tidwall(G): get-seq        1,000,000 ops in 192ms, 5,204,371/sec, 192 ns/op
tidwall(M): get-seq        1,000,000 ops in 158ms, 6,348,145/sec, 157 ns/op
tidwall:    get-seq-hint   1,000,000 ops in 170ms, 5,897,138/sec, 169 ns/op
tidwall(G): get-seq-hint   1,000,000 ops in 122ms, 8,209,155/sec, 121 ns/op

** random set **
google:     set-rand       1,000,000 ops in 1219ms, 820,124/sec, 1219 ns/op, 46.4 MB, 48.7 bytes/op
google(G):  set-rand       1,000,000 ops in 1023ms, 977,986/sec, 1022 ns/op, 34.5 MB, 36.2 bytes/op
tidwall:    set-rand       1,000,000 ops in 1564ms, 639,231/sec, 1564 ns/op, 46.4 MB, 48.6 bytes/op
tidwall(G): set-rand       1,000,000 ops in 1014ms, 985,957/sec, 1014 ns/op, 34.6 MB, 36.3 bytes/op
tidwall(M): set-rand       1,000,000 ops in 928ms, 1,077,164/sec, 928 ns/op, 34.6 MB, 36.3 bytes/op
tidwall:    set-rand-hint  1,000,000 ops in 1691ms, 591,293/sec, 1691 ns/op, 46.4 MB, 48.6 bytes/op
tidwall(G): set-rand-hint  1,000,000 ops in 1132ms, 883,455/sec, 1131 ns/op, 34.6 MB, 36.3 bytes/op
tidwall:    set-after-copy 1,000,000 ops in 1677ms, 596,379/sec, 1676 ns/op
tidwall(G): set-after-copy 1,000,000 ops in 1347ms, 742,636/sec, 1346 ns/op
tidwall:    load-rand      1,000,000 ops in 1605ms, 623,086/sec, 1604 ns/op, 46.4 MB, 48.6 bytes/op
tidwall(G): load-rand      1,000,000 ops in 1038ms, 963,701/sec, 1037 ns/op, 34.6 MB, 36.3 bytes/op
tidwall(M): load-rand      1,000,000 ops in 987ms, 1,013,427/sec, 986 ns/op, 34.6 MB, 36.3 bytes/op
go-map:     set            1,000,000 ops in 374ms, 2,671,251/sec, 374 ns/op

** random get **
google:     get-rand       1,000,000 ops in 1859ms, 537,977/sec, 1858 ns/op
google(G):  get-rand       1,000,000 ops in 1065ms, 939,267/sec, 1064 ns/op
tidwall:    get-rand       1,000,000 ops in 1802ms, 555,022/sec, 1801 ns/op
tidwall(G): get-rand       1,000,000 ops in 1067ms, 937,608/sec, 1066 ns/op
tidwall(M): get-rand       1,000,000 ops in 1004ms, 996,438/sec, 1003 ns/op
tidwall:    get-rand-hint  1,000,000 ops in 1885ms, 530,381/sec, 1885 ns/op
tidwall(G): get-rand-hint  1,000,000 ops in 1173ms, 852,559/sec, 1172 ns/op
go-map:     get            1,000,000 ops in 127ms, 7,845,457/sec, 127 ns/op

** range **
google:     ascend        1,000,000 ops in 12ms, 85,634,533/sec, 11 ns/op
google(G):  ascend        1,000,000 ops in 12ms, 82,858,485/sec, 12 ns/op
tidwall:    ascend        1,000,000 ops in 10ms, 95,869,243/sec, 10 ns/op
tidwall(G): iter          1,000,000 ops in 14ms, 69,245,752/sec, 14 ns/op
tidwall(G): scan          1,000,000 ops in 10ms, 102,703,389/sec, 9 ns/op
tidwall(G): walk          1,000,000 ops in 4ms, 225,436,292/sec, 4 ns/op
go-arr:     for-loop      1,000,000 ops in 2ms, 429,130,217/sec, 2 ns/op
```