### PR TITLE
Add pile implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ Benchmark utility for the [tidwall/btree](https://github.com/tidwall/btree) Go p
 
 - `google`: The [google/btree](https://github.com/google/btree) package (without generics)
 - `google(G)`: The [google/btree](https://github.com/google/btree) package (generics)
+- `pile(M)`: The [pascaldekloe/pile](https://github.com/pascaldekloe/pile) package (generics)
 - `tidwall`: The [tidwall/btree](https://github.com/tidwall/btree) package (without generics)
 - `tidwall(G)`: The [tidwall/btree](https://github.com/tidwall/btree) package (generics)
 - `tidwall(M)`: The [tidwall/btree](https://github.com/tidwall/btree) package (generics using the `btree.Map` type)
 - `go-arr`: A simple Go array
 
 The following benchmarks were run on my 2021 Macbook Pro M1 Max 
-using Go version 1.19.3.  
+using Go version 1.19.3.
 All items are key/value pairs where the key is a string filled with 16 random digits such as `5204379379828236`, and the value is the int64 representation of the key.
 The degree is 32.  
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/google/btree v1.1.2
-	github.com/pascaldekloe/pile v0.3.0
+	github.com/pascaldekloe/pile v1.0.0
 	github.com/tidwall/btree v1.5.0
 	github.com/tidwall/lotsa v1.0.3
 )

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/google/btree v1.1.2
+	github.com/pascaldekloe/pile v0.3.0
 	github.com/tidwall/btree v1.5.0
 	github.com/tidwall/lotsa v1.0.3
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/google/btree v1.1.2 h1:xf4v41cLI2Z6FxbKm+8Bu+m8ifhj15JuZ9sa0jZCMUU=
 github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
+github.com/pascaldekloe/pile v0.3.0 h1:QchhmRQpt91G7I2+YvzRBTyJnvKlmA99WoKKIwuoOz0=
+github.com/pascaldekloe/pile v0.3.0/go.mod h1:M/9EGMjN4zh2QHpJ2MP3W8ROS+IjWCnrxZzw4aHH6W8=
 github.com/tidwall/btree v1.5.0 h1:iV0yVY/frd7r6qGBXfEYs7DH0gTDgrKTrDjS7xt/IyQ=
 github.com/tidwall/btree v1.5.0/go.mod h1:LGm8L/DZjPLmeWGjv5kFrY8dL4uVhMmzmmLYmsObdKE=
 github.com/tidwall/lotsa v1.0.3 h1:lFAp3PIsS58FPmz+LzhE1mcZ67tBBCRPv5j66g6y7sg=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/google/btree v1.1.2 h1:xf4v41cLI2Z6FxbKm+8Bu+m8ifhj15JuZ9sa0jZCMUU=
 github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
-github.com/pascaldekloe/pile v0.3.0 h1:QchhmRQpt91G7I2+YvzRBTyJnvKlmA99WoKKIwuoOz0=
-github.com/pascaldekloe/pile v0.3.0/go.mod h1:M/9EGMjN4zh2QHpJ2MP3W8ROS+IjWCnrxZzw4aHH6W8=
+github.com/pascaldekloe/pile v1.0.0 h1:neIaYlQL0telfqSSZyJVF/7p0CZLRTWXZERDN5tHr60=
+github.com/pascaldekloe/pile v1.0.0/go.mod h1:M/9EGMjN4zh2QHpJ2MP3W8ROS+IjWCnrxZzw4aHH6W8=
 github.com/tidwall/btree v1.5.0 h1:iV0yVY/frd7r6qGBXfEYs7DH0gTDgrKTrDjS7xt/IyQ=
 github.com/tidwall/btree v1.5.0/go.mod h1:LGm8L/DZjPLmeWGjv5kFrY8dL4uVhMmzmmLYmsObdKE=
 github.com/tidwall/lotsa v1.0.3 h1:lFAp3PIsS58FPmz+LzhE1mcZ67tBBCRPv5j66g6y7sg=

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	gbtree "github.com/google/btree"
+	"github.com/pascaldekloe/pile"
 	tbtree "github.com/tidwall/btree"
 	"github.com/tidwall/lotsa"
 )
@@ -102,6 +103,7 @@ func main() {
 
 	gtr := newGBTree(degree)
 	gtrG := newGBTreeG(degree)
+	pileM := &pile.Map[keyT, valT]{}
 	ttr := newTBTree(degree)
 	ttrG := newTBTreeG(degree)
 	ttrM := newTBTreeM(degree)
@@ -135,6 +137,13 @@ func main() {
 		gtrG = newGBTreeG(degree)
 		lotsa.Ops(N, 1, func(i, _ int) {
 			gtrG.ReplaceOrInsert(items[i])
+		})
+
+		// pile
+		print("pile(M):    set-seq        ")
+		pileM = &pile.Map[keyT, valT]{}
+		lotsa.Ops(N, 1, func(i, _ int) {
+			pileM.Put(items[i].key, items[i].val)
 		})
 
 		// non-generics tidwall
@@ -206,6 +215,13 @@ func main() {
 				panic(re)
 			}
 		})
+		print("pile(M):    get-seq        ")
+		lotsa.Ops(N, 1, func(i, _ int) {
+			re, ok := pileM.Find(items[i].key)
+			if !ok {
+				panic(re)
+			}
+		})
 		print("tidwall:    get-seq        ")
 		lotsa.Ops(N, 1, func(i, _ int) {
 			re := ttr.Get(items[i])
@@ -259,6 +275,11 @@ func main() {
 			gtrG = newGBTreeG(degree)
 			lotsa.Ops(N, 1, func(i, _ int) {
 				gtrG.ReplaceOrInsert(items[i])
+			})
+			print("pile(M):    set-rand       ")
+			pileM = &pile.Map[keyT, valT]{}
+			lotsa.Ops(N, 1, func(i, _ int) {
+				pileM.Put(items[i].key, items[i].val)
 			})
 			print("tidwall:    set-rand       ")
 			ttr = newTBTree(degree)
@@ -319,12 +340,14 @@ func main() {
 		shuffleInts()
 		gtr = newGBTree(degree)
 		gtrG = newGBTreeG(degree)
+		pileM = &pile.Map[keyT, valT]{}
 		ttr = newTBTree(degree)
 		ttrM = newTBTreeM(degree)
 		ttrG = newTBTreeG(degree)
 		for _, item := range items {
 			gtr.ReplaceOrInsert(item)
 			gtrG.ReplaceOrInsert(item)
+			pileM.Put(item.key, item.val)
 			ttrG.Set(item)
 			ttr.Set(item)
 			ttrM.Set(item.key, item.val)
@@ -341,6 +364,13 @@ func main() {
 		print("google(G):  get-rand       ")
 		lotsa.Ops(N, 1, func(i, _ int) {
 			re, ok := gtrG.Get(items[i])
+			if !ok {
+				panic(re)
+			}
+		})
+		print("pile(M):    get-rand       ")
+		lotsa.Ops(N, 1, func(i, _ int) {
+			re, ok := pileM.Find(items[i].key)
 			if !ok {
 				panic(re)
 			}
@@ -401,6 +431,13 @@ func main() {
 				gtrG.Ascend(func(item itemT) bool {
 					return true
 				})
+			}
+		})
+		print("pile(M):    iter          ")
+		lotsa.Ops(N, 1, func(i, _ int) {
+			if i == 0 {
+				for c, ok := pileM.Least(); ok; ok = c.Ascend() {
+				}
 			}
 		})
 		print("tidwall:    ascend        ")


### PR DESCRIPTION
Here's another B-tree implementation to compare with. Pile nodes are limed to 3 pairs and 4 children. The search paths are fully coded with `if`/`else` jumps instead of slice loops.

It shines in predictable/sequential operations, and it falls short on high randomness. The iterator could use some of your tweaks as well.

I'm interested in hearing your thoughts.


```
degree=32, key=string (16 bytes), val=int64, count=1000000

** sequential set **
google:     set-seq        1,000,000 ops in 215ms, 4,648,683/sec, 215 ns/op, 56.8 MB, 59.6 bytes/op
google(G):  set-seq        1,000,000 ops in 169ms, 5,918,659/sec, 168 ns/op, 49.7 MB, 52.1 bytes/op
pile(M):    set-seq        1,000,000 ops in 73ms, 13,687,200/sec, 73 ns/op, 61.1 MB, 64.0 bytes/op
tidwall:    set-seq        1,000,000 ops in 138ms, 7,251,040/sec, 137 ns/op, 56.4 MB, 59.1 bytes/op
tidwall(G): set-seq        1,000,000 ops in 116ms, 8,633,478/sec, 115 ns/op, 49.2 MB, 51.6 bytes/op
tidwall(M): set-seq        1,000,000 ops in 88ms, 11,344,235/sec, 88 ns/op, 49.2 MB, 51.6 bytes/op
tidwall:    set-seq-hint   1,000,000 ops in 86ms, 11,648,811/sec, 85 ns/op, 56.4 MB, 59.1 bytes/op
tidwall(G): set-seq-hint   1,000,000 ops in 55ms, 18,075,828/sec, 55 ns/op, 49.2 MB, 51.6 bytes/op
tidwall:    load-seq       1,000,000 ops in 50ms, 19,895,069/sec, 50 ns/op, 56.4 MB, 59.1 bytes/op
tidwall(G): load-seq       1,000,000 ops in 29ms, 34,425,431/sec, 29 ns/op, 49.2 MB, 51.6 bytes/op
tidwall(M): load-seq       1,000,000 ops in 25ms, 39,486,217/sec, 25 ns/op, 49.2 MB, 51.6 bytes/op
go-arr:     append         1,000,000 ops in 16ms, 61,112,240/sec, 16 ns/op, 26.5 MB, 27.7 bytes/op

** sequential get **
google:     get-seq        1,000,000 ops in 200ms, 5,008,237/sec, 199 ns/op
google(G):  get-seq        1,000,000 ops in 168ms, 5,958,287/sec, 167 ns/op
pile(M):    get-seq        1,000,000 ops in 75ms, 13,353,757/sec, 74 ns/op
tidwall:    get-seq        1,000,000 ops in 154ms, 6,490,393/sec, 154 ns/op
tidwall(G): get-seq        1,000,000 ops in 113ms, 8,856,255/sec, 112 ns/op
tidwall(M): get-seq        1,000,000 ops in 91ms, 10,984,248/sec, 91 ns/op
tidwall:    get-seq-hint   1,000,000 ops in 82ms, 12,259,121/sec, 81 ns/op
tidwall(G): get-seq-hint   1,000,000 ops in 50ms, 20,129,347/sec, 49 ns/op

** random set **
google:     set-rand       1,000,000 ops in 1179ms, 848,020/sec, 1179 ns/op, 46.5 MB, 48.7 bytes/op
google(G):  set-rand       1,000,000 ops in 714ms, 1,400,476/sec, 714 ns/op, 34.5 MB, 36.2 bytes/op
pile(M):    set-rand       1,000,000 ops in 590ms, 1,694,558/sec, 590 ns/op, 63.7 MB, 66.8 bytes/op
tidwall:    set-rand       1,000,000 ops in 908ms, 1,101,053/sec, 908 ns/op, 46.4 MB, 48.7 bytes/op
tidwall(G): set-rand       1,000,000 ops in 583ms, 1,716,731/sec, 582 ns/op, 34.6 MB, 36.3 bytes/op
tidwall(M): set-rand       1,000,000 ops in 546ms, 1,832,092/sec, 545 ns/op, 34.6 MB, 36.3 bytes/op
tidwall:    set-rand-hint  1,000,000 ops in 938ms, 1,065,611/sec, 938 ns/op, 46.4 MB, 48.7 bytes/op
tidwall(G): set-rand-hint  1,000,000 ops in 625ms, 1,600,836/sec, 624 ns/op, 34.6 MB, 36.3 bytes/op
tidwall:    set-after-copy 1,000,000 ops in 1061ms, 942,249/sec, 1061 ns/op
tidwall(G): set-after-copy 1,000,000 ops in 650ms, 1,539,573/sec, 649 ns/op
tidwall:    load-rand      1,000,000 ops in 929ms, 1,076,282/sec, 929 ns/op, 46.4 MB, 48.7 bytes/op
tidwall(G): load-rand      1,000,000 ops in 603ms, 1,659,107/sec, 602 ns/op, 34.6 MB, 36.3 bytes/op
tidwall(M): load-rand      1,000,000 ops in 557ms, 1,794,853/sec, 557 ns/op, 34.6 MB, 36.3 bytes/op

** random get **
google:     get-rand       1,000,000 ops in 1606ms, 622,754/sec, 1605 ns/op
google(G):  get-rand       1,000,000 ops in 837ms, 1,195,308/sec, 836 ns/op
pile(M):    get-rand       1,000,000 ops in 664ms, 1,505,360/sec, 664 ns/op
tidwall:    get-rand       1,000,000 ops in 1173ms, 852,275/sec, 1173 ns/op
tidwall(G): get-rand       1,000,000 ops in 668ms, 1,497,615/sec, 667 ns/op
tidwall(M): get-rand       1,000,000 ops in 628ms, 1,592,822/sec, 627 ns/op
tidwall:    get-rand-hint  1,000,000 ops in 1203ms, 831,430/sec, 1202 ns/op
tidwall(G): get-rand-hint  1,000,000 ops in 721ms, 1,386,903/sec, 721 ns/op

** range **
google:     ascend        1,000,000 ops in 10ms, 102,403,061/sec, 9 ns/op
google(G):  ascend        1,000,000 ops in 11ms, 90,130,689/sec, 11 ns/op
pile(M):    iter          1,000,000 ops in 30ms, 32,953,905/sec, 30 ns/op
tidwall:    ascend        1,000,000 ops in 10ms, 104,482,737/sec, 9 ns/op
tidwall(G): iter          1,000,000 ops in 10ms, 97,820,242/sec, 10 ns/op
tidwall(G): scan          1,000,000 ops in 9ms, 113,325,157/sec, 8 ns/op
tidwall(G): walk          1,000,000 ops in 3ms, 332,133,997/sec, 3 ns/op
go-arr:     for-loop      1,000,000 ops in 2ms, 622,277,535/sec, 1 ns/op
```